### PR TITLE
add disconnectFromDevice() to allow explicit BLE disconnection

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,15 @@ _plugin_singleton.scanForAddress("AA:BB:CC:DD:EE:FF")
 _plugin_singleton.scanForName("MyDevice")
 ```
 
+## Disconnecting
+
+To disconnect from a device, call `disconnectFromDevice()` with the device's MAC address:
+```python
+_plugin_singleton.disconnectFromDevice("AA:BB:CC:DD:EE:FF")
+```
+
+A `bluetooth_device_disconnected` signal is emitted when the connection is closed, with the device name, MAC address, and a status string. Disconnecting this way suppresses the automatic reconnection that would otherwise occur after an unexpected disconnect.
+
 ## Measurement signals
 
 Once connected, the plugin emits signals as measurement notifications arrive from the device:

--- a/app/src/main/java/com/duffrecords/godotandroidble/GodotAndroidBle.kt
+++ b/app/src/main/java/com/duffrecords/godotandroidble/GodotAndroidBle.kt
@@ -57,6 +57,8 @@ class GodotAndroidBle(godot: Godot): GodotPlugin(godot) {
 
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
+    private val intentionalDisconnects = mutableSetOf<String>()
+
     // UUIDs for the Blood Pressure service (BLP)
     private val BLP_SERVICE_UUID: UUID = UUID.fromString("00001810-0000-1000-8000-00805f9b34fb")
     private val BLP_MEASUREMENT_CHARACTERISTIC_UUID: UUID = UUID.fromString("00002A35-0000-1000-8000-00805f9b34fb")
@@ -322,6 +324,7 @@ class GodotAndroidBle(godot: Godot): GodotPlugin(godot) {
                 peripheral.address,
                 status.name
             )
+            if (intentionalDisconnects.remove(peripheral.address)) return
             handler.postDelayed(
                 { centralManager.autoConnect(peripheral, bluetoothPeripheralCallback) },
                 15000
@@ -565,6 +568,13 @@ class GodotAndroidBle(godot: Godot): GodotPlugin(godot) {
         } else {
             centralManager.connect(peripheral, bluetoothPeripheralCallback)
         }
+    }
+
+    @UsedByGodot
+    fun disconnectFromDevice(address: String) {
+        val peripheral = centralManager.getPeripheral(address)
+        intentionalDisconnects.add(address)
+        centralManager.cancelConnection(peripheral)
     }
 }
 


### PR DESCRIPTION
Implements disconnectFromDevice(address) which cancels the GATT connection and suppresses the automatic reconnect that fires after unexpected disconnects, using an intentionalDisconnects set checked in onDisconnected.